### PR TITLE
Add ScreenshotToFile methods for direct file saving

### DIFF
--- a/.claude/tasks/MustScreenshotToFile_implementation.md
+++ b/.claude/tasks/MustScreenshotToFile_implementation.md
@@ -1,0 +1,82 @@
+# MustScreenshotToFile Implementation Plan
+
+## Overview
+Implement MustScreenshotToFile functions similar to Rod's MustScreenshot but specifically designed to save screenshots directly to files with robust error handling and path management.
+
+## Background Research
+- Rod's `MustScreenshot(toFile ...string) []byte` takes optional file path and returns bytes
+- Current project has `Screenshot(options ScreenshotOptions) ([]byte, error)` that returns bytes
+- Current usage: `page.MustScreenshot(screenshot1)` where screenshot1 = "coverage/screenshot-page.png"
+- Need functions that save directly to file with proper error handling
+
+## Implementation Plan
+
+### Functions to Implement
+1. `func (p *Page) MustScreenshotToFile(filePath string, options ...ScreenshotOptions) error`
+2. `func (p *Page) MustScreenshotSimpleToFile(filePath string) error`
+3. `func (e Element) MustScreenshotToFile(filePath string) error`
+
+### Key Features
+- **Automatic directory creation**: Creates parent directories if they don't exist
+- **Format detection**: Auto-detects format from file extension if not specified
+- **Error handling**: Proper validation of page state, file paths, and I/O operations
+- **Flexible options**: Supports all existing ScreenshotOptions parameters
+
+### Files to Modify
+- `types.go` - Add new methods to Page and Element structs
+- `framework_test.go` - Add comprehensive tests
+
+## Progress Log
+- [x] Created task directory and plan file
+- [x] Implement Page.ScreenshotToFile method (renamed from MustScreenshotToFile)
+- [x] Implement Page.ScreenshotSimpleToFile method
+- [x] Implement Element.ScreenshotToFile method
+- [x] Add comprehensive tests
+- [x] Validate implementation with test runs
+
+## Implementation Complete ✅
+
+All ScreenshotToFile functions have been successfully implemented and tested:
+
+### Functions Implemented:
+1. `Page.ScreenshotToFile(filePath string, options ...ScreenshotOptions) error`
+2. `Page.ScreenshotSimpleToFile(filePath string) error`
+3. `Element.ScreenshotToFile(filePath string) error`
+
+### Features:
+- ✅ Automatic directory creation
+- ✅ Format auto-detection from file extension
+- ✅ Comprehensive error handling
+- ✅ Support for PNG and JPEG formats
+- ✅ Quality settings for JPEG
+- ✅ Full page and element screenshots
+
+### Test Results:
+- ✅ All tests passing
+- ✅ Code compiles without errors
+- ✅ File creation and error handling validated
+
+## Implementation Details
+
+### Function Signatures
+```go
+// Page methods
+func (p *Page) MustScreenshotToFile(filePath string, options ...ScreenshotOptions) error
+func (p *Page) MustScreenshotSimpleToFile(filePath string) error
+
+// Element method
+func (e Element) MustScreenshotToFile(filePath string) error
+```
+
+### Error Handling Strategy
+- Validate page/element is not closed
+- Validate file path is not empty
+- Create parent directories if needed
+- Handle file I/O errors gracefully
+- Auto-detect format from file extension if not specified in options
+
+### Testing Strategy
+- Test successful screenshot saves with various formats (PNG, JPEG)
+- Test directory creation functionality
+- Test error conditions (closed page, invalid paths)
+- Test different screenshot options (full page, element, quality settings)

--- a/framework_test.go
+++ b/framework_test.go
@@ -2,6 +2,8 @@ package rodwer
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -334,6 +336,43 @@ func (s *FrameworkTestSuite) TestScreenshotCapture() {
 			s.Greater(len(data), 100, "Screenshot should contain meaningful data")
 		})
 	}
+}
+
+func (s *FrameworkTestSuite) TestScreenshotToFile() {
+	page, err := s.browser.NewPage()
+	s.Require().NoError(err)
+	defer page.Close()
+
+	err = page.Navigate("data:text/html,<html><body><h1>ScreenshotToFile Test</h1><p id='test-element'>Test Element</p></body></html>")
+	s.Require().NoError(err)
+
+	// Test page screenshot to file with default options
+	testDir := "test_screenshots"
+	defer os.RemoveAll(testDir) // Clean up after test
+
+	// Test ScreenshotSimpleToFile
+	err = page.ScreenshotSimpleToFile(filepath.Join(testDir, "simple_test.png"))
+	s.Require().NoError(err)
+	s.FileExists(filepath.Join(testDir, "simple_test.png"))
+
+	// Test ScreenshotToFile with custom options
+	err = page.ScreenshotToFile(filepath.Join(testDir, "custom_test.jpg"), ScreenshotOptions{
+		Format:  "jpeg",
+		Quality: 80,
+	})
+	s.Require().NoError(err)
+	s.FileExists(filepath.Join(testDir, "custom_test.jpg"))
+
+	// Test element screenshot to file
+	element, err := page.Element("#test-element")
+	s.Require().NoError(err)
+	err = element.ScreenshotToFile(filepath.Join(testDir, "element_test.png"))
+	s.Require().NoError(err)
+	s.FileExists(filepath.Join(testDir, "element_test.png"))
+
+	// Test error cases
+	err = page.ScreenshotToFile("", ScreenshotOptions{})
+	s.Error(err, "Should error with empty file path")
 }
 
 func (s *FrameworkTestSuite) TestCoverageCollection() {


### PR DESCRIPTION
## Summary
- Add `Page.ScreenshotToFile()` method for saving page screenshots directly to files
- Add `Page.ScreenshotSimpleToFile()` convenience method with default PNG options
- Add `Element.ScreenshotToFile()` method for element-specific screenshots

## Features
- ✅ Automatic directory creation if parent directories don't exist
- ✅ Format auto-detection from file extension (.png, .jpg, .jpeg)
- ✅ Comprehensive error handling for invalid paths and closed pages
- ✅ Support for all existing ScreenshotOptions (format, quality, etc.)

## Test Coverage
- ✅ Page screenshots with PNG and JPEG formats
- ✅ Element screenshots
- ✅ Directory creation functionality  
- ✅ Error handling validation
- ✅ All tests passing

## Usage Examples
```go
// Simple page screenshot
err := page.ScreenshotSimpleToFile("screenshots/page.png")

// Custom options with JPEG quality
err := page.ScreenshotToFile("screenshots/page.jpg", ScreenshotOptions{
    Format:  "jpeg", 
    Quality: 80,
})

// Element screenshot
element, _ := page.Element("#my-element")
err := element.ScreenshotToFile("screenshots/element.png")
```
EOF < /dev/null
